### PR TITLE
Fix: Category autoplay does not advance to the next category

### DIFF
--- a/main.js
+++ b/main.js
@@ -2418,7 +2418,7 @@ function generate(content, initialCategory = null, targetRowId = null) {
   radios.forEach(function (radio) {
     radio.addEventListener('change', function () {
       // 【關鍵修正】只在不是由程式碼觸發導航時才執行
-      if (!isNavigatingViaCode && !isCrossCategoryPlaying) {
+      if (!isNavigatingViaCode) { // <--- 拿掉 !isCrossCategoryPlaying 以修正 regression
         if (this.checked) {
           const selectedCategory = this.value;
           


### PR DESCRIPTION
This commit fixes a regression where the audio player would stop after finishing a category instead of automatically proceeding to the next one.

The issue was caused by a faulty conditional check in the 'change' event listener for the category radio buttons. A flag `isCrossCategoryPlaying` was correctly set to `true` to indicate an automatic transition, but the event listener contained a check `!isCrossCategoryPlaying`, which blocked the logic from executing.

This commit removes the contradictory `!isCrossCategoryPlaying` check, allowing the `buildTableAndSetupPlayback` function to be called as intended when the player advances to the next category.