### PR TITLE
fix: Ensure search popup closes on search

### DIFF
--- a/main.js
+++ b/main.js
@@ -1400,7 +1400,7 @@ function initializeAppUI() {
         return;
     }
 
-    searchContainer.classList.remove('active');
+    searchPopup.style.display = 'none';
     searchInput.blur();
 
     const learningPanel = document.getElementById('learningSelectionPanel');


### PR DESCRIPTION
This change corrects the logic for hiding the search options popup (`#search-popup`) after a search is triggered.

The popup was being shown by setting its `style.display` property, but the code attempted to hide it by removing a CSS class on a parent container (`searchContainer.classList.remove('active')`). This mismatch caused the popup to remain open after a search.

The fix replaces the incorrect hiding mechanism with the correct one, `searchPopup.style.display = 'none'`, ensuring the popup closes as expected.