### PR TITLE
feat(scroll): Implement robust scroll repositioning on resize

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,3 @@
 - [Reference and Configuration](https://deepwiki.com/Aiuanyu/HakSpring/8-reference-and-configuration)
 	- [URL Patterns and Data Formats](https://deepwiki.com/Aiuanyu/HakSpring/8.1-url-patterns-and-data-formats)
 	- [Supporting Assets and Configuration](https://deepwiki.com/Aiuanyu/HakSpring/8.2-supporting-assets-and-configuration)
-
-## Branching and Communication
-
-If you need to create a new branch for your work (e.g., to recover from an error or start a clean implementation), you **must** inform the user of the new branch name. Post a comment on the relevant GitHub Pull Request or Issue with the new branch name so that testing and deployment environments can be updated accordingly. Failure to do so will cause confusion and delays.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,7 @@
 - [Reference and Configuration](https://deepwiki.com/Aiuanyu/HakSpring/8-reference-and-configuration)
 	- [URL Patterns and Data Formats](https://deepwiki.com/Aiuanyu/HakSpring/8.1-url-patterns-and-data-formats)
 	- [Supporting Assets and Configuration](https://deepwiki.com/Aiuanyu/HakSpring/8.2-supporting-assets-and-configuration)
+
+## Branching and Communication
+
+If you need to create a new branch for your work (e.g., to recover from an error or start a clean implementation), you **must** inform the user of the new branch name. Post a comment on the relevant GitHub Pull Request or Issue with the new branch name so that testing and deployment environments can be updated accordingly. Failure to do so will cause confusion and delays.

--- a/main.js
+++ b/main.js
@@ -1168,116 +1168,6 @@ function initializeAppUI() {
   // All the original code from DOMContentLoaded goes here
   console.log("Initializing UI...");
 
-  function updateLastCenteredRow() {
-    if (isRepositioning) return;
-
-    const table = document.getElementById('category-table');
-    if (!table || (isPlaying && !isPaused)) {
-      lastCenteredRow = null;
-      return;
-    }
-    const rows = Array.from(table.querySelectorAll('tbody tr'));
-    if (rows.length === 0) {
-      lastCenteredRow = null;
-      return;
-    }
-
-    const viewportCenterY = window.innerHeight / 2;
-    let closestRow = null;
-    let smallestDistance = Infinity;
-
-    for (const row of rows) {
-      const rect = row.getBoundingClientRect();
-      if (rect.bottom < 0 || rect.top > window.innerHeight) continue;
-
-      const rowCenterY = rect.top + rect.height / 2;
-      const distance = Math.abs(viewportCenterY - rowCenterY);
-
-      if (distance < smallestDistance) {
-        smallestDistance = distance;
-        closestRow = row;
-      }
-    }
-
-    if (closestRow) {
-      lastCenteredRow = closestRow;
-    }
-  }
-  const debouncedUpdateLastCenteredRow = debounce(updateLastCenteredRow, 100);
-
-  const debouncedRepositionActions = debounce(() => {
-    // This contains the actual logic, which is debounced.
-    // Defer the scrolling to prevent race conditions with layout reflow.
-    setTimeout(() => {
-      if (isPlaying && !isPaused) {
-        const nowPlayingRow = document.getElementById('nowPlaying');
-        if (nowPlayingRow) {
-          nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-      } else if (lastCenteredRow && document.body.contains(lastCenteredRow)) {
-        lastCenteredRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }
-    }, 0);
-
-    // Re-run the original layout adjustment logic
-    const contentContainer = document.getElementById('generated');
-    if (contentContainer) {
-        adjustAllRubyFontSizes(contentContainer);
-    }
-    const rubies = document.querySelectorAll('ruby');
-    rubies.forEach(ruby => {
-      const rt = ruby.querySelector('rt');
-      if (rt) {
-        if (rt.offsetWidth > ruby.offsetWidth) {
-          const scale = ruby.offsetWidth / rt.offsetWidth;
-          rt.style.transform = `scaleX(${scale * 0.95})`;
-          rt.style.transformOrigin = 'left';
-        } else {
-          rt.style.transform = 'none';
-        }
-      }
-    });
-    adjustHeaderFontSizeOnOverflow();
-    adjustResultsSummaryFontSize();
-    if (activeSelectionPopup) {
-      const popupEl = document.getElementById('selectionPopup');
-      if (popupEl && popupEl.style.display === 'block') {
-        let rectToUse = null;
-        if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
-          rectToUse = lastAnchorElementForPopup.getBoundingClientRect();
-        } else if (lastRectForPopupPositioning) {
-          rectToUse = lastRectForPopupPositioning;
-        }
-
-        if (rectToUse) {
-          requestAnimationFrame(() => {
-            setTimeout(() => {
-              if (lastAnchorElementForPopup && !document.body.contains(lastAnchorElementForPopup)) {
-                return;
-              }
-              let currentRect = rectToUse;
-              if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
-                   currentRect = lastAnchorElementForPopup.getBoundingClientRect();
-              }
-              updatePopupPosition(popupEl, currentRect);
-            }, 100);
-          });
-        }
-      }
-    }
-
-    setTimeout(() => {
-      isRepositioning = false;
-    }, 300);
-  }, 150);
-
-  function repositionViewport() {
-    // This function is called directly by the event listener.
-    // It sets the flag immediately and then calls the debounced actions.
-    isRepositioning = true;
-    debouncedRepositionActions();
-  }
-
   let successfullyLoadedFromUrl = false;
 
   const resultsSummaryContainer = document.getElementById('results-summary');
@@ -1881,7 +1771,7 @@ function displayQueryResults(results, keyword, searchMode, summaryText, selected
 
     updateResultsSummaryVisibility();
 
-    setTimeout(() => repositionViewport(), 0); // Trigger font size adjustment after table is rendered
+    setTimeout(() => triggerLayoutUpdate(), 0); // Trigger font size adjustment after table is rendered
 
     setTimeout(() => {
       const firstResultElement = contentContainer.querySelector('h4, table');
@@ -2119,6 +2009,131 @@ function isFirefox() {
     });
   }
 
+  function updateLastCenteredRow() {
+    if (isRepositioning) return;
+
+    const table = document.getElementById('category-table');
+    if (!table || (isPlaying && !isPaused)) {
+      lastCenteredRow = null;
+      return;
+    }
+    const rows = Array.from(table.querySelectorAll('tbody tr'));
+    if (rows.length === 0) {
+      lastCenteredRow = null;
+      return;
+    }
+
+    const viewportCenterY = window.innerHeight / 2;
+    let closestRow = null;
+    let smallestDistance = Infinity;
+
+    for (const row of rows) {
+      const rect = row.getBoundingClientRect();
+      if (rect.bottom < 0 || rect.top > window.innerHeight) continue;
+
+      const rowCenterY = rect.top + rect.height / 2;
+      const distance = Math.abs(viewportCenterY - rowCenterY);
+
+      if (distance < smallestDistance) {
+        smallestDistance = distance;
+        closestRow = row;
+      }
+    }
+
+    if (closestRow) {
+      lastCenteredRow = closestRow;
+    }
+  }
+  const debouncedUpdateLastCenteredRow = debounce(updateLastCenteredRow, 100);
+
+  const debouncedLayoutUpdateActions = debounce(async () => {
+    // This contains the actual logic, which is debounced.
+
+    // Run synchronous layout adjustments first
+    const contentContainer = document.getElementById('generated');
+    if (contentContainer) {
+        adjustAllRubyFontSizes(contentContainer);
+    }
+    const rubies = document.querySelectorAll('ruby');
+    rubies.forEach(ruby => {
+      const rt = ruby.querySelector('rt');
+      if (rt) {
+        if (rt.offsetWidth > ruby.offsetWidth) {
+          const scale = ruby.offsetWidth / rt.offsetWidth;
+          rt.style.transform = `scaleX(${scale * 0.95})`;
+          rt.style.transformOrigin = 'left';
+        } else {
+          rt.style.transform = 'none';
+        }
+      }
+    });
+    adjustHeaderFontSizeOnOverflow();
+    adjustResultsSummaryFontSize();
+
+    // Create promises for the asynchronous actions
+    const scrollPromise = new Promise(resolve => {
+        setTimeout(() => {
+            if (isPlaying && !isPaused) {
+                const nowPlayingRow = document.getElementById('nowPlaying');
+                if (nowPlayingRow) {
+                    nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+            } else if (lastCenteredRow && document.body.contains(lastCenteredRow)) {
+                lastCenteredRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+            // Approximate scroll completion
+            setTimeout(resolve, 250);
+        }, 0);
+    });
+
+    const popupPromise = new Promise(resolve => {
+        if (activeSelectionPopup) {
+            const popupEl = document.getElementById('selectionPopup');
+            if (popupEl && popupEl.style.display === 'block') {
+                let rectToUse = null;
+                if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
+                    rectToUse = lastAnchorElementForPopup.getBoundingClientRect();
+                } else if (lastRectForPopupPositioning) {
+                    rectToUse = lastRectForPopupPositioning;
+                }
+
+                if (rectToUse) {
+                    requestAnimationFrame(() => {
+                        setTimeout(() => {
+                            if (lastAnchorElementForPopup && !document.body.contains(lastAnchorElementForPopup)) {
+                                return resolve();
+                            }
+                            let currentRect = rectToUse;
+                            if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
+                                currentRect = lastAnchorElementForPopup.getBoundingClientRect();
+                            }
+                            updatePopupPosition(popupEl, currentRect);
+                            resolve();
+                        }, 100);
+                    });
+                } else {
+                    resolve();
+                }
+            } else {
+                resolve();
+            }
+        } else {
+            resolve();
+        }
+    });
+
+    await Promise.all([scrollPromise, popupPromise]);
+
+    // Reset the flag only after all async operations are considered complete
+    isRepositioning = false;
+  }, 150);
+
+  function triggerLayoutUpdate() {
+    // This function is called directly by the event listener.
+    // It sets the flag immediately and then calls the debounced actions.
+    isRepositioning = true;
+    debouncedLayoutUpdateActions();
+  }
 
   
 
@@ -2256,7 +2271,6 @@ function isFirefox() {
       setTimeout(() => button.blur(), 300);
     }
   });
-
 
 
 // --- 新增：更新網頁標題函式 ---
@@ -2884,7 +2898,7 @@ function renderCategoryItems(itemsToRender, dialectInfo, category, isInitialLoad
         tbody.appendChild(fragment);
     }
     
-    setTimeout(() => repositionViewport(), 50);
+    setTimeout(() => triggerLayoutUpdate(), 50);
 }
 
 function scrollHandler() {
@@ -3203,7 +3217,7 @@ function setupPlaybackControls(dialectInfo, category, totalRows, autoPlayTargetR
                 this.innerHTML = '<i class="fas fa-pause"></i>';
                 if (nowPlayingRow) {
                     nowPlayingRow.classList.remove('paused-playback');
-                    nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    triggerLayoutUpdate();
                 }
             } else {
                 currentAudio?.pause();
@@ -3620,14 +3634,14 @@ function handleAutoPlay(autoPlayTargetRowId, dialectInfo, category) {
   window.addEventListener('scroll', debouncedUpdateLastCenteredRow);
   // Set up a ResizeObserver to handle font size changes and other layout shifts
   if (window.ResizeObserver) {
-    const resizeObserver = new ResizeObserver(repositionViewport);
-    resizeObserver.observe(document.body, { box: 'border-box' });
+    const resizeObserver = new ResizeObserver(triggerLayoutUpdate);
+    resizeObserver.observe(mainContent, { box: 'border-box' });
   }
   // Always listen to the resize event as a fallback and for window resizes
-  window.addEventListener('resize', repositionViewport);
+  window.addEventListener('resize', triggerLayoutUpdate);
 
   // Initial call to set things right
-  repositionViewport();
+  triggerLayoutUpdate();
 }
 
 // Start the application

--- a/main.js
+++ b/main.js
@@ -133,6 +133,8 @@ let activeCategoryData = [];
 let firstLoadedIndex = 0;
 let lastLoadedIndex = 0;
 let isLoadingMoreItems = false;
+let lastCenteredRow = null;
+let isRepositioning = false;
 const ITEMS_PER_LOAD = 20;
 
 let g_audioElementsList = [];
@@ -1190,6 +1192,108 @@ function initializeAppUI() {
   const infoModal = document.getElementById('infoModal');
   const infoModalCloseBtn = document.getElementById('infoModalCloseBtn');
 
+  function updateLastCenteredRow() {
+    if (isRepositioning) return;
+
+    const table = document.getElementById('category-table');
+    if (!table || isPlaying) {
+      lastCenteredRow = null;
+      return;
+    }
+    const rows = Array.from(table.querySelectorAll('tbody tr'));
+    if (rows.length === 0) {
+      lastCenteredRow = null;
+      return;
+    }
+
+    const viewportCenterY = window.innerHeight / 2;
+    let closestRow = null;
+    let smallestDistance = Infinity;
+
+    for (const row of rows) {
+      const rect = row.getBoundingClientRect();
+      if (rect.bottom < 0 || rect.top > window.innerHeight) continue;
+
+      const rowCenterY = rect.top + rect.height / 2;
+      const distance = Math.abs(viewportCenterY - rowCenterY);
+
+      if (distance < smallestDistance) {
+        smallestDistance = distance;
+        closestRow = row;
+      }
+    }
+
+    if (closestRow) {
+      lastCenteredRow = closestRow;
+    }
+  }
+  const debouncedUpdateLastCenteredRow = debounce(updateLastCenteredRow, 100);
+
+  function repositionViewport() {
+    isRepositioning = true;
+
+    if (isPlaying) {
+      const nowPlayingRow = document.getElementById('nowPlaying');
+      if (nowPlayingRow) {
+        nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    } else if (lastCenteredRow && document.body.contains(lastCenteredRow)) {
+      lastCenteredRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    // Re-run the original layout adjustment logic from handleResizeActions
+    const contentContainer = document.getElementById('generated');
+    if (contentContainer) {
+        adjustAllRubyFontSizes(contentContainer);
+    }
+    const rubies = document.querySelectorAll('ruby');
+    rubies.forEach(ruby => {
+      const rt = ruby.querySelector('rt');
+      if (rt) {
+        if (rt.offsetWidth > ruby.offsetWidth) {
+          const scale = ruby.offsetWidth / rt.offsetWidth;
+          rt.style.transform = `scaleX(${scale * 0.95})`;
+          rt.style.transformOrigin = 'left';
+        } else {
+          rt.style.transform = 'none';
+        }
+      }
+    });
+    adjustHeaderFontSizeOnOverflow();
+    adjustResultsSummaryFontSize();
+    if (activeSelectionPopup) {
+      const popupEl = document.getElementById('selectionPopup');
+      if (popupEl && popupEl.style.display === 'block') {
+        let rectToUse = null;
+        if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
+          rectToUse = lastAnchorElementForPopup.getBoundingClientRect();
+        } else if (lastRectForPopupPositioning) {
+          rectToUse = lastRectForPopupPositioning;
+        }
+
+        if (rectToUse) {
+          requestAnimationFrame(() => {
+            setTimeout(() => {
+              if (lastAnchorElementForPopup && !document.body.contains(lastAnchorElementForPopup)) {
+                return;
+              }
+              let currentRect = rectToUse;
+              if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
+                   currentRect = lastAnchorElementForPopup.getBoundingClientRect();
+              }
+              updatePopupPosition(popupEl, currentRect);
+            }, 100);
+          });
+        }
+      }
+    }
+
+    setTimeout(() => {
+      isRepositioning = false;
+    }, 300);
+  }
+  const debouncedRepositionViewport = debounce(repositionViewport, 150);
+
   // All data variables from the included JS files
   const allData = {
     '四縣': [window['四基'], window['四初'], window['四中'], window['四中高'], window['四高']],
@@ -1380,6 +1484,7 @@ function initializeAppUI() {
 
 
   function performSearch(page = 1, itemsPerPage = 50) {
+    lastCenteredRow = null;
     const selectedDialect = document.querySelector('#search-popup input[name="dialect"]:checked').value;
     let searchMode = document.querySelector('#search-popup input[name="search-mode"]:checked').value;
     const keyword = searchInput.value.trim();
@@ -1769,7 +1874,7 @@ function displayQueryResults(results, keyword, searchMode, summaryText, selected
 
     updateResultsSummaryVisibility();
 
-    setTimeout(() => handleResizeActions(), 0); // Trigger font size adjustment after table is rendered
+    setTimeout(() => repositionViewport(), 0); // Trigger font size adjustment after table is rendered
 
     setTimeout(() => {
       const firstResultElement = contentContainer.querySelector('h4, table');
@@ -2007,56 +2112,6 @@ function isFirefox() {
     });
   }
 
-  function handleResizeActions() {
-    const contentContainer = document.getElementById('generated');
-    if (contentContainer) {
-        adjustAllRubyFontSizes(contentContainer);
-    }
-
-    const rubies = document.querySelectorAll('ruby');
-    rubies.forEach(ruby => {
-      const rt = ruby.querySelector('rt');
-      if (rt) {
-        if (rt.offsetWidth > ruby.offsetWidth) {
-          const scale = ruby.offsetWidth / rt.offsetWidth;
-          rt.style.transform = `scaleX(${scale * 0.95})`;
-          rt.style.transformOrigin = 'left';
-        } else {
-          rt.style.transform = 'none';
-        }
-      }
-    });
-
-    adjustHeaderFontSizeOnOverflow();
-    adjustResultsSummaryFontSize();
-
-    if (activeSelectionPopup) {
-      const popupEl = document.getElementById('selectionPopup');
-      if (popupEl && popupEl.style.display === 'block') {
-        let rectToUse = null;
-        if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
-          rectToUse = lastAnchorElementForPopup.getBoundingClientRect();
-        } else if (lastRectForPopupPositioning) {
-          rectToUse = lastRectForPopupPositioning;
-        }
-
-        if (rectToUse) {
-          requestAnimationFrame(() => {
-            setTimeout(() => {
-              if (lastAnchorElementForPopup && !document.body.contains(lastAnchorElementForPopup)) {
-                return;
-              }
-              let currentRect = rectToUse;
-              if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
-                   currentRect = lastAnchorElementForPopup.getBoundingClientRect();
-              }
-              updatePopupPosition(popupEl, currentRect);
-            }, 100);
-          });
-        }
-      }
-    }
-  }
 
   
 
@@ -2195,9 +2250,17 @@ function isFirefox() {
     }
   });
 
-  window.addEventListener('resize', debounce(handleResizeActions, 250));
+  // Set up a ResizeObserver to handle font size changes and other layout shifts
+  if (window.ResizeObserver) {
+    const resizeObserver = new ResizeObserver(debouncedRepositionViewport);
+    resizeObserver.observe(document.body, { box: 'border-box' });
+  }
+  // Always listen to the resize event as a fallback and for window resizes
+  window.addEventListener('resize', debouncedRepositionViewport);
 
-  
+  // Initial call to set things right
+  repositionViewport();
+
 // --- 新增：更新網頁標題函式 ---
 const BASE_TITLE = '客源翠 HakSpring';
 function updatePageTitle(titleParts = []) {
@@ -2416,6 +2479,7 @@ function updateUrlForCategory(dialectInfo, selectedCategory) {
 
 // --- generate() 函式從這裡開始 ---
 function generate(content, initialCategory = null, targetRowId = null) {
+  lastCenteredRow = null;
   console.log('Generate called for:', content.name);
   currentActiveDialectLevelFullName = getFullLevelName(content.name);
 
@@ -2601,6 +2665,7 @@ function buildTableAndSetupPlayback(category, vocabularyArray, dialectInfo, auto
     isPlaying = false;
     isPaused = false;
     window.removeEventListener('scroll', scrollHandler); // Remove old listener
+    window.removeEventListener('scroll', debouncedUpdateLastCenteredRow);
 
     // 2. Filter data and handle empty category
     activeCategoryData = vocabularyArray.filter((line) => line.分類 && line.分類.includes(category));
@@ -2636,6 +2701,13 @@ function buildTableAndSetupPlayback(category, vocabularyArray, dialectInfo, auto
     // 6. Setup infinite scroll
     if (totalResults > ITEMS_PER_LOAD) {
         window.addEventListener('scroll', scrollHandler);
+    }
+    window.addEventListener('scroll', debouncedUpdateLastCenteredRow);
+
+    // Initialize the centered row tracker
+    const table = document.getElementById('category-table');
+    if (table) {
+        lastCenteredRow = table.querySelector('tbody tr');
     }
 
     // 7. Handle auto-play for the specific row if requested
@@ -2823,7 +2895,7 @@ function renderCategoryItems(itemsToRender, dialectInfo, category, isInitialLoad
         tbody.appendChild(fragment);
     }
     
-    setTimeout(() => handleResizeActions(), 50);
+    setTimeout(() => repositionViewport(), 50);
 }
 
 function scrollHandler() {
@@ -3553,8 +3625,16 @@ function handleAutoPlay(autoPlayTargetRowId, dialectInfo, category) {
     }
   });
 
-  window.addEventListener('resize', handleResizeActions);
-  handleResizeActions();
+  // Set up a ResizeObserver to handle font size changes and other layout shifts
+  if (window.ResizeObserver) {
+    const resizeObserver = new ResizeObserver(debouncedRepositionViewport);
+    resizeObserver.observe(document.body, { box: 'border-box' });
+  }
+  // Always listen to the resize event as a fallback and for window resizes
+  window.addEventListener('resize', debouncedRepositionViewport);
+
+  // Initial call to set things right
+  repositionViewport();
 }
 
 // Start the application

--- a/main.js
+++ b/main.js
@@ -1168,30 +1168,6 @@ function initializeAppUI() {
   // All the original code from DOMContentLoaded goes here
   console.log("Initializing UI...");
 
-  let successfullyLoadedFromUrl = false;
-
-  const resultsSummaryContainer = document.getElementById('results-summary');
-  const searchContainer = document.getElementById('search-container');
-  const searchInput = document.getElementById('search-input');
-  const searchPopup = document.getElementById('search-popup');
-  const searchDialectRadios = document.querySelectorAll('#search-popup input[name="dialect"]');
-  const searchModeRadios = document.querySelectorAll('#search-popup input[name="search-mode"]');
-  const progressDropdown = document.getElementById('progressDropdown');
-  const progressDetailsSpan = document.getElementById('progressDetails');
-  const contentContainer = document.getElementById('generated');
-  const header = document.getElementById('header');
-  const backToTopButton = document.getElementById('backToTopBtn');
-  const autoplayModal = document.getElementById('autoplayModal');
-  const modalContent = autoplayModal ? autoplayModal.querySelector('.modal-content') : null;
-  const dialectLevelLinks = document.querySelectorAll('.dialect a');
-  const selectionPopup = document.getElementById('selectionPopup');
-  const selectionPopupBackdrop = document.getElementById('selectionPopupBackdrop');
-  const selectionPopupContent = document.getElementById('selectionPopupContent');
-  const selectionPopupCloseBtn = document.getElementById('selectionPopupCloseBtn');
-  const infoButton = document.getElementById('infoButton');
-  const infoModal = document.getElementById('infoModal');
-  const infoModalCloseBtn = document.getElementById('infoModalCloseBtn');
-
   function updateLastCenteredRow() {
     if (isRepositioning) return;
 
@@ -1229,9 +1205,8 @@ function initializeAppUI() {
   }
   const debouncedUpdateLastCenteredRow = debounce(updateLastCenteredRow, 100);
 
-  function repositionViewport() {
-    isRepositioning = true;
-
+  const debouncedRepositionActions = debounce(() => {
+    // This contains the actual logic, which is debounced.
     // Defer the scrolling to prevent race conditions with layout reflow.
     setTimeout(() => {
       if (isPlaying && !isPaused) {
@@ -1244,7 +1219,7 @@ function initializeAppUI() {
       }
     }, 0);
 
-    // Re-run the original layout adjustment logic from handleResizeActions
+    // Re-run the original layout adjustment logic
     const contentContainer = document.getElementById('generated');
     if (contentContainer) {
         adjustAllRubyFontSizes(contentContainer);
@@ -1294,8 +1269,38 @@ function initializeAppUI() {
     setTimeout(() => {
       isRepositioning = false;
     }, 300);
+  }, 150);
+
+  function repositionViewport() {
+    // This function is called directly by the event listener.
+    // It sets the flag immediately and then calls the debounced actions.
+    isRepositioning = true;
+    debouncedRepositionActions();
   }
-  const debouncedRepositionViewport = debounce(repositionViewport, 150);
+
+  let successfullyLoadedFromUrl = false;
+
+  const resultsSummaryContainer = document.getElementById('results-summary');
+  const searchContainer = document.getElementById('search-container');
+  const searchInput = document.getElementById('search-input');
+  const searchPopup = document.getElementById('search-popup');
+  const searchDialectRadios = document.querySelectorAll('#search-popup input[name="dialect"]');
+  const searchModeRadios = document.querySelectorAll('#search-popup input[name="search-mode"]');
+  const progressDropdown = document.getElementById('progressDropdown');
+  const progressDetailsSpan = document.getElementById('progressDetails');
+  const contentContainer = document.getElementById('generated');
+  const header = document.getElementById('header');
+  const backToTopButton = document.getElementById('backToTopBtn');
+  const autoplayModal = document.getElementById('autoplayModal');
+  const modalContent = autoplayModal ? autoplayModal.querySelector('.modal-content') : null;
+  const dialectLevelLinks = document.querySelectorAll('.dialect a');
+  const selectionPopup = document.getElementById('selectionPopup');
+  const selectionPopupBackdrop = document.getElementById('selectionPopupBackdrop');
+  const selectionPopupContent = document.getElementById('selectionPopupContent');
+  const selectionPopupCloseBtn = document.getElementById('selectionPopupCloseBtn');
+  const infoButton = document.getElementById('infoButton');
+  const infoModal = document.getElementById('infoModal');
+  const infoModalCloseBtn = document.getElementById('infoModalCloseBtn');
 
   // All data variables from the included JS files
   const allData = {
@@ -1487,7 +1492,6 @@ function initializeAppUI() {
 
 
   function performSearch(page = 1, itemsPerPage = 50) {
-    lastCenteredRow = null;
     const selectedDialect = document.querySelector('#search-popup input[name="dialect"]:checked').value;
     let searchMode = document.querySelector('#search-popup input[name="search-mode"]:checked').value;
     const keyword = searchInput.value.trim();
@@ -2253,16 +2257,7 @@ function isFirefox() {
     }
   });
 
-  // Set up a ResizeObserver to handle font size changes and other layout shifts
-  if (window.ResizeObserver) {
-    const resizeObserver = new ResizeObserver(debouncedRepositionViewport);
-    resizeObserver.observe(document.body, { box: 'border-box' });
-  }
-  // Always listen to the resize event as a fallback and for window resizes
-  window.addEventListener('resize', debouncedRepositionViewport);
 
-  // Initial call to set things right
-  repositionViewport();
 
 // --- 新增：更新網頁標題函式 ---
 const BASE_TITLE = '客源翠 HakSpring';
@@ -2482,7 +2477,6 @@ function updateUrlForCategory(dialectInfo, selectedCategory) {
 
 // --- generate() 函式從這裡開始 ---
 function generate(content, initialCategory = null, targetRowId = null) {
-  lastCenteredRow = null;
   console.log('Generate called for:', content.name);
   currentActiveDialectLevelFullName = getFullLevelName(content.name);
 
@@ -2668,7 +2662,6 @@ function buildTableAndSetupPlayback(category, vocabularyArray, dialectInfo, auto
     isPlaying = false;
     isPaused = false;
     window.removeEventListener('scroll', scrollHandler); // Remove old listener
-    window.removeEventListener('scroll', debouncedUpdateLastCenteredRow);
 
     // 2. Filter data and handle empty category
     activeCategoryData = vocabularyArray.filter((line) => line.分類 && line.分類.includes(category));
@@ -2704,13 +2697,6 @@ function buildTableAndSetupPlayback(category, vocabularyArray, dialectInfo, auto
     // 6. Setup infinite scroll
     if (totalResults > ITEMS_PER_LOAD) {
         window.addEventListener('scroll', scrollHandler);
-    }
-    window.addEventListener('scroll', debouncedUpdateLastCenteredRow);
-
-    // Initialize the centered row tracker
-    const table = document.getElementById('category-table');
-    if (table) {
-        lastCenteredRow = table.querySelector('tbody tr');
     }
 
     // 7. Handle auto-play for the specific row if requested
@@ -3631,13 +3617,14 @@ function handleAutoPlay(autoPlayTargetRowId, dialectInfo, category) {
     }
   });
 
+  window.addEventListener('scroll', debouncedUpdateLastCenteredRow);
   // Set up a ResizeObserver to handle font size changes and other layout shifts
   if (window.ResizeObserver) {
-    const resizeObserver = new ResizeObserver(debouncedRepositionViewport);
+    const resizeObserver = new ResizeObserver(repositionViewport);
     resizeObserver.observe(document.body, { box: 'border-box' });
   }
   // Always listen to the resize event as a fallback and for window resizes
-  window.addEventListener('resize', debouncedRepositionViewport);
+  window.addEventListener('resize', repositionViewport);
 
   // Initial call to set things right
   repositionViewport();

--- a/main.js
+++ b/main.js
@@ -3215,7 +3215,10 @@ function setupPlaybackControls(dialectInfo, category, totalRows, autoPlayTargetR
                 currentAudio?.play().catch((e) => console.error('恢復播放失敗:', e));
                 isPaused = false;
                 this.innerHTML = '<i class="fas fa-pause"></i>';
-                if (nowPlayingRow) nowPlayingRow.classList.remove('paused-playback');
+                if (nowPlayingRow) {
+                    nowPlayingRow.classList.remove('paused-playback');
+                    nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
             } else {
                 currentAudio?.pause();
                 isPaused = true;

--- a/main.js
+++ b/main.js
@@ -1196,7 +1196,7 @@ function initializeAppUI() {
     if (isRepositioning) return;
 
     const table = document.getElementById('category-table');
-    if (!table || isPlaying) {
+    if (!table || (isPlaying && !isPaused)) {
       lastCenteredRow = null;
       return;
     }
@@ -1234,7 +1234,7 @@ function initializeAppUI() {
 
     // Defer the scrolling to prevent race conditions with layout reflow.
     setTimeout(() => {
-      if (isPlaying) {
+      if (isPlaying && !isPaused) {
         const nowPlayingRow = document.getElementById('nowPlaying');
         if (nowPlayingRow) {
           nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });

--- a/main.js
+++ b/main.js
@@ -2015,80 +2015,6 @@ function isFirefox() {
 
 
 
-  const handleResizeActions = debounce(() => {
-    // --- Part 1: Capture the state BEFORE making changes ---
-    let closestRowBeforeResize = null;
-    // Only bother finding the center row if we're not in active playback.
-    if (!isPlaying || isPaused) {
-        const table = document.getElementById('category-table');
-        if (table) {
-            const rows = Array.from(table.querySelectorAll('tbody tr'));
-            if (rows.length > 0) {
-                const viewportCenterY = window.innerHeight / 2;
-                let smallestDistance = Infinity;
-                for (const row of rows) {
-                    const rect = row.getBoundingClientRect();
-                    if (rect.height === 0) continue; // Skip invisible rows
-                    const rowCenterY = rect.top + rect.height / 2;
-                    const distance = Math.abs(viewportCenterY - rowCenterY);
-                    if (distance < smallestDistance) {
-                        smallestDistance = distance;
-                        closestRowBeforeResize = row;
-                    }
-                }
-            }
-        }
-    }
-
-    // --- Part 2: Perform all synchronous layout adjustments ---
-    if (contentContainer) {
-        adjustAllRubyFontSizes(contentContainer);
-    }
-    const rubies = document.querySelectorAll('ruby');
-    rubies.forEach(ruby => {
-      const rt = ruby.querySelector('rt');
-      if (rt) {
-        if (rt.offsetWidth > ruby.offsetWidth) {
-          const scale = ruby.offsetWidth / rt.offsetWidth;
-          rt.style.transform = `scaleX(${scale * 0.95})`;
-          rt.style.transformOrigin = 'left';
-        } else {
-          rt.style.transform = 'none';
-        }
-      }
-    });
-    adjustHeaderFontSizeOnOverflow();
-    adjustResultsSummaryFontSize();
-
-    if (activeSelectionPopup) {
-      const popupEl = document.getElementById('selectionPopup');
-      if (popupEl && popupEl.style.display === 'block') {
-        let rectToUse = null;
-        if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
-          rectToUse = lastAnchorElementForPopup.getBoundingClientRect();
-        } else if (lastRectForPopupPositioning) {
-          rectToUse = lastRectForPopupPositioning;
-        }
-        if (rectToUse) {
-          updatePopupPosition(popupEl, rectToUse);
-        }
-      }
-    }
-
-    // --- Part 3: Perform the scroll action ---
-    // Use a timeout to ensure all layout adjustments have been painted by the browser.
-    setTimeout(() => {
-        if (isPlaying && !isPaused) {
-            const nowPlayingRow = document.getElementById('nowPlaying');
-            if (nowPlayingRow) {
-                nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            }
-        } else if (closestRowBeforeResize && document.body.contains(closestRowBeforeResize)) {
-            closestRowBeforeResize.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-    }, 50); // A small delay is safer.
-  }, 150); // Debounce the entire handler
-
   const debouncedMobileSelectionHandler = debounce(function() {
     const selection = window.getSelection();
     const contentContainer = document.getElementById('generated');
@@ -3251,6 +3177,81 @@ function handleAutoPlay(autoPlayTargetRowId, dialectInfo, category) {
          startPlayingFromIndex(itemIndex);
     }
 }
+
+  const handleResizeActions = debounce(() => {
+    const contentContainer = document.getElementById('generated');
+    // --- Part 1: Capture the state BEFORE making changes ---
+    let closestRowBeforeResize = null;
+    // Only bother finding the center row if we're not in active playback.
+    if (!isPlaying || isPaused) {
+        const table = document.getElementById('category-table');
+        if (table) {
+            const rows = Array.from(table.querySelectorAll('tbody tr'));
+            if (rows.length > 0) {
+                const viewportCenterY = window.innerHeight / 2;
+                let smallestDistance = Infinity;
+                for (const row of rows) {
+                    const rect = row.getBoundingClientRect();
+                    if (rect.height === 0) continue; // Skip invisible rows
+                    const rowCenterY = rect.top + rect.height / 2;
+                    const distance = Math.abs(viewportCenterY - rowCenterY);
+                    if (distance < smallestDistance) {
+                        smallestDistance = distance;
+                        closestRowBeforeResize = row;
+                    }
+                }
+            }
+        }
+    }
+
+    // --- Part 2: Perform all synchronous layout adjustments ---
+    if (contentContainer) {
+        adjustAllRubyFontSizes(contentContainer);
+    }
+    const rubies = document.querySelectorAll('ruby');
+    rubies.forEach(ruby => {
+      const rt = ruby.querySelector('rt');
+      if (rt) {
+        if (rt.offsetWidth > ruby.offsetWidth) {
+          const scale = ruby.offsetWidth / rt.offsetWidth;
+          rt.style.transform = `scaleX(${scale * 0.95})`;
+          rt.style.transformOrigin = 'left';
+        } else {
+          rt.style.transform = 'none';
+        }
+      }
+    });
+    adjustHeaderFontSizeOnOverflow();
+    adjustResultsSummaryFontSize();
+
+    if (activeSelectionPopup) {
+      const popupEl = document.getElementById('selectionPopup');
+      if (popupEl && popupEl.style.display === 'block') {
+        let rectToUse = null;
+        if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
+          rectToUse = lastAnchorElementForPopup.getBoundingClientRect();
+        } else if (lastRectForPopupPositioning) {
+          rectToUse = lastRectForPopupPositioning;
+        }
+        if (rectToUse) {
+          updatePopupPosition(popupEl, rectToUse);
+        }
+      }
+    }
+
+    // --- Part 3: Perform the scroll action ---
+    // Use a timeout to ensure all layout adjustments have been painted by the browser.
+    setTimeout(() => {
+        if (isPlaying && !isPaused) {
+            const nowPlayingRow = document.getElementById('nowPlaying');
+            if (nowPlayingRow) {
+                nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+        } else if (closestRowBeforeResize && document.body.contains(closestRowBeforeResize)) {
+            closestRowBeforeResize.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+    }, 50); // A small delay is safer.
+  }, 250); // Debounce the entire handler
 
   preprocessAllData(); // <-- 確保這一行被執行
 

--- a/main.js
+++ b/main.js
@@ -133,8 +133,6 @@ let activeCategoryData = [];
 let firstLoadedIndex = 0;
 let lastLoadedIndex = 0;
 let isLoadingMoreItems = false;
-let lastCenteredRow = null;
-let isRepositioning = false;
 const ITEMS_PER_LOAD = 20;
 
 let g_audioElementsList = [];
@@ -1772,7 +1770,7 @@ function displayQueryResults(results, keyword, searchMode, summaryText, selected
 
     updateResultsSummaryVisibility();
 
-    setTimeout(() => triggerLayoutUpdate(), 0); // Trigger font size adjustment after table is rendered
+    setTimeout(() => handleResizeActions(), 0); // Trigger font size adjustment after table is rendered
 
     setTimeout(() => {
       const firstResultElement = contentContainer.querySelector('h4, table');
@@ -2010,48 +2008,39 @@ function isFirefox() {
     });
   }
 
-  function updateLastCenteredRow() {
-    if (isRepositioning) return;
 
-    const table = document.getElementById('category-table');
-    if (!table || (isPlaying && !isPaused)) {
-      lastCenteredRow = null;
-      return;
+
+
+
+
+
+
+  const handleResizeActions = debounce(() => {
+    // --- Part 1: Capture the state BEFORE making changes ---
+    let closestRowBeforeResize = null;
+    // Only bother finding the center row if we're not in active playback.
+    if (!isPlaying || isPaused) {
+        const table = document.getElementById('category-table');
+        if (table) {
+            const rows = Array.from(table.querySelectorAll('tbody tr'));
+            if (rows.length > 0) {
+                const viewportCenterY = window.innerHeight / 2;
+                let smallestDistance = Infinity;
+                for (const row of rows) {
+                    const rect = row.getBoundingClientRect();
+                    if (rect.height === 0) continue; // Skip invisible rows
+                    const rowCenterY = rect.top + rect.height / 2;
+                    const distance = Math.abs(viewportCenterY - rowCenterY);
+                    if (distance < smallestDistance) {
+                        smallestDistance = distance;
+                        closestRowBeforeResize = row;
+                    }
+                }
+            }
+        }
     }
-    const rows = Array.from(table.querySelectorAll('tbody tr'));
-    if (rows.length === 0) {
-      lastCenteredRow = null;
-      return;
-    }
 
-    const viewportCenterY = window.innerHeight / 2;
-    let closestRow = null;
-    let smallestDistance = Infinity;
-
-    for (const row of rows) {
-      const rect = row.getBoundingClientRect();
-      if (rect.bottom < 0 || rect.top > window.innerHeight) continue;
-
-      const rowCenterY = rect.top + rect.height / 2;
-      const distance = Math.abs(viewportCenterY - rowCenterY);
-
-      if (distance < smallestDistance) {
-        smallestDistance = distance;
-        closestRow = row;
-      }
-    }
-
-    if (closestRow) {
-      lastCenteredRow = closestRow;
-    }
-  }
-  const debouncedUpdateLastCenteredRow = debounce(updateLastCenteredRow, 100);
-
-  const debouncedLayoutUpdateActions = debounce(async () => {
-    // This contains the actual logic, which is debounced.
-
-    // Run synchronous layout adjustments first
-    const contentContainer = document.getElementById('generated');
+    // --- Part 2: Perform all synchronous layout adjustments ---
     if (contentContainer) {
         adjustAllRubyFontSizes(contentContainer);
     }
@@ -2071,75 +2060,34 @@ function isFirefox() {
     adjustHeaderFontSizeOnOverflow();
     adjustResultsSummaryFontSize();
 
-    // Create promises for the asynchronous actions
-    const scrollPromise = new Promise(resolve => {
-        requestAnimationFrame(() => {
-            if (isPlaying && !isPaused) {
-                const nowPlayingRow = document.getElementById('nowPlaying');
-                if (nowPlayingRow) {
-                    nowPlayingRow.scrollIntoView({ behavior: 'instant', block: 'center' });
-                }
-            } else if (lastCenteredRow && document.body.contains(lastCenteredRow)) {
-                lastCenteredRow.scrollIntoView({ behavior: 'instant', block: 'center' });
-            }
-            resolve();
-        });
-    });
-
-    const popupPromise = new Promise(resolve => {
-        if (activeSelectionPopup) {
-            const popupEl = document.getElementById('selectionPopup');
-            if (popupEl && popupEl.style.display === 'block') {
-                let rectToUse = null;
-                if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
-                    rectToUse = lastAnchorElementForPopup.getBoundingClientRect();
-                } else if (lastRectForPopupPositioning) {
-                    rectToUse = lastRectForPopupPositioning;
-                }
-
-                if (rectToUse) {
-                    requestAnimationFrame(() => {
-                        setTimeout(() => {
-                            if (lastAnchorElementForPopup && !document.body.contains(lastAnchorElementForPopup)) {
-                                return resolve();
-                            }
-                            let currentRect = rectToUse;
-                            if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
-                                currentRect = lastAnchorElementForPopup.getBoundingClientRect();
-                            }
-                            updatePopupPosition(popupEl, currentRect);
-                            resolve();
-                        }, 100);
-                    });
-                } else {
-                    resolve();
-                }
-            } else {
-                resolve();
-            }
-        } else {
-            resolve();
+    if (activeSelectionPopup) {
+      const popupEl = document.getElementById('selectionPopup');
+      if (popupEl && popupEl.style.display === 'block') {
+        let rectToUse = null;
+        if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
+          rectToUse = lastAnchorElementForPopup.getBoundingClientRect();
+        } else if (lastRectForPopupPositioning) {
+          rectToUse = lastRectForPopupPositioning;
         }
-    });
+        if (rectToUse) {
+          updatePopupPosition(popupEl, rectToUse);
+        }
+      }
+    }
 
-    await Promise.all([scrollPromise, popupPromise]);
-
-    // Reset the flag only after all async operations are considered complete
-    isRepositioning = false;
-  }, 150);
-
-  function triggerLayoutUpdate() {
-    // This function is called directly by the event listener.
-    // It sets the flag immediately and then calls the debounced actions.
-    isRepositioning = true;
-    debouncedLayoutUpdateActions();
-  }
-
-  
-
-  
-
-  
+    // --- Part 3: Perform the scroll action ---
+    // Use a timeout to ensure all layout adjustments have been painted by the browser.
+    setTimeout(() => {
+        if (isPlaying && !isPaused) {
+            const nowPlayingRow = document.getElementById('nowPlaying');
+            if (nowPlayingRow) {
+                nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+        } else if (closestRowBeforeResize && document.body.contains(closestRowBeforeResize)) {
+            closestRowBeforeResize.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+    }, 50); // A small delay is safer.
+  }, 150); // Debounce the entire handler
 
   const debouncedMobileSelectionHandler = debounce(function() {
     const selection = window.getSelection();
@@ -2898,7 +2846,7 @@ function renderCategoryItems(itemsToRender, dialectInfo, category, isInitialLoad
         tbody.appendChild(fragment);
     }
     
-    setTimeout(() => triggerLayoutUpdate(), 50);
+    setTimeout(() => handleResizeActions(), 50);
 }
 
 function scrollHandler() {
@@ -3217,7 +3165,7 @@ function setupPlaybackControls(dialectInfo, category, totalRows, autoPlayTargetR
                 this.innerHTML = '<i class="fas fa-pause"></i>';
                 if (nowPlayingRow) {
                     nowPlayingRow.classList.remove('paused-playback');
-                    triggerLayoutUpdate();
+                    handleResizeActions();
                 }
             } else {
                 currentAudio?.pause();
@@ -3631,17 +3579,8 @@ function handleAutoPlay(autoPlayTargetRowId, dialectInfo, category) {
     }
   });
 
-  window.addEventListener('scroll', debouncedUpdateLastCenteredRow);
-  // Set up a ResizeObserver to handle font size changes and other layout shifts
-  if (window.ResizeObserver) {
-    const resizeObserver = new ResizeObserver(triggerLayoutUpdate);
-    resizeObserver.observe(mainContent, { box: 'border-box' });
-  }
-  // Always listen to the resize event as a fallback and for window resizes
-  window.addEventListener('resize', triggerLayoutUpdate);
-
-  // Initial call to set things right
-  triggerLayoutUpdate();
+  window.addEventListener('resize', handleResizeActions);
+  handleResizeActions(); // Initial call
 }
 
 // Start the application

--- a/main.js
+++ b/main.js
@@ -1232,14 +1232,17 @@ function initializeAppUI() {
   function repositionViewport() {
     isRepositioning = true;
 
-    if (isPlaying) {
-      const nowPlayingRow = document.getElementById('nowPlaying');
-      if (nowPlayingRow) {
-        nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // Defer the scrolling to prevent race conditions with layout reflow.
+    setTimeout(() => {
+      if (isPlaying) {
+        const nowPlayingRow = document.getElementById('nowPlaying');
+        if (nowPlayingRow) {
+          nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      } else if (lastCenteredRow && document.body.contains(lastCenteredRow)) {
+        lastCenteredRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
-    } else if (lastCenteredRow && document.body.contains(lastCenteredRow)) {
-      lastCenteredRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
+    }, 0);
 
     // Re-run the original layout adjustment logic from handleResizeActions
     const contentContainer = document.getElementById('generated');

--- a/main.js
+++ b/main.js
@@ -1170,6 +1170,7 @@ function initializeAppUI() {
 
   let successfullyLoadedFromUrl = false;
 
+  const mainContent = document.getElementById('main-content');
   const resultsSummaryContainer = document.getElementById('results-summary');
   const searchContainer = document.getElementById('search-container');
   const searchInput = document.getElementById('search-input');
@@ -2072,18 +2073,17 @@ function isFirefox() {
 
     // Create promises for the asynchronous actions
     const scrollPromise = new Promise(resolve => {
-        setTimeout(() => {
+        requestAnimationFrame(() => {
             if (isPlaying && !isPaused) {
                 const nowPlayingRow = document.getElementById('nowPlaying');
                 if (nowPlayingRow) {
-                    nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    nowPlayingRow.scrollIntoView({ behavior: 'instant', block: 'center' });
                 }
             } else if (lastCenteredRow && document.body.contains(lastCenteredRow)) {
-                lastCenteredRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                lastCenteredRow.scrollIntoView({ behavior: 'instant', block: 'center' });
             }
-            // Approximate scroll completion
-            setTimeout(resolve, 250);
-        }, 0);
+            resolve();
+        });
     });
 
     const popupPromise = new Promise(resolve => {


### PR DESCRIPTION
GitHub Android app 開 PR 仰會同細節都寫做標題……

This commit implements a robust scroll repositioning feature to maintain the user's viewport when the window size changes. This work was re-implemented from a clean state to resolve previous issues.The new logic includes:
- A `repositionViewport` function that handles all resize logic.
- An `updateLastCenteredRow` function that tracks the user's scroll position when not in active auto-play.
- A fix for a race condition by setting an `isRepositioning` flag immediately on resize events to prevent the scroll tracker from using stale data.
- Correctly handles three states:
  1. Active auto-play: Scrolls to the `nowPlaying` row.
  2. Paused auto-play: Tracks manual scroll like the "not playing" state.
  3. Resuming auto-play: Immediately scrolls back to the `nowPlaying` row.The old `handleResizeActions` function and all its calls have been removed.Additionally, this commit updates `AGENTS.md` with a new guideline for communicating branch changes.