### PR TITLE
Fix: Improve Viewport Scrolling on Resize and Pause/Resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,7 @@
 - [Reference and Configuration](https://deepwiki.com/Aiuanyu/HakSpring/8-reference-and-configuration)
 	- [URL Patterns and Data Formats](https://deepwiki.com/Aiuanyu/HakSpring/8.1-url-patterns-and-data-formats)
 	- [Supporting Assets and Configuration](https://deepwiki.com/Aiuanyu/HakSpring/8.2-supporting-assets-and-configuration)
+
+## Branching and Communication
+
+If you need to create a new branch for your work (e.g., to recover from an error or start a clean implementation), you **must** inform the user of the new branch name. Post a comment on the relevant GitHub Pull Request or Issue with the new branch name so that testing and deployment environments can be updated accordingly. Failure to do so will cause confusion and delays.

--- a/main.js
+++ b/main.js
@@ -133,6 +133,8 @@ let activeCategoryData = [];
 let firstLoadedIndex = 0;
 let lastLoadedIndex = 0;
 let isLoadingMoreItems = false;
+let lastCenteredRow = null;
+let isRepositioning = false;
 const ITEMS_PER_LOAD = 20;
 
 let g_audioElementsList = [];
@@ -1166,6 +1168,132 @@ function initializeAppUI() {
   // All the original code from DOMContentLoaded goes here
   console.log("Initializing UI...");
 
+  function updateLastCenteredRow() {
+    if (isRepositioning) return;
+
+    const table = document.getElementById('category-table');
+    if (!table || (isPlaying && !isPaused)) {
+      lastCenteredRow = null;
+      return;
+    }
+    const rows = Array.from(table.querySelectorAll('tbody tr'));
+    if (rows.length === 0) {
+      lastCenteredRow = null;
+      return;
+    }
+
+    const viewportCenterY = window.innerHeight / 2;
+    let closestRow = null;
+    let smallestDistance = Infinity;
+
+    for (const row of rows) {
+      const rect = row.getBoundingClientRect();
+      if (rect.bottom < 0 || rect.top > window.innerHeight) continue;
+
+      const rowCenterY = rect.top + rect.height / 2;
+      const distance = Math.abs(viewportCenterY - rowCenterY);
+
+      if (distance < smallestDistance) {
+        smallestDistance = distance;
+        closestRow = row;
+      }
+    }
+
+    if (closestRow) {
+      lastCenteredRow = closestRow;
+    }
+  }
+  const debouncedUpdateLastCenteredRow = debounce(updateLastCenteredRow, 100);
+
+  const debouncedLayoutUpdateActions = debounce(async () => {
+    // This contains the actual logic, which is debounced.
+
+    // Run synchronous layout adjustments first
+    const contentContainer = document.getElementById('generated');
+    if (contentContainer) {
+        adjustAllRubyFontSizes(contentContainer);
+    }
+    const rubies = document.querySelectorAll('ruby');
+    rubies.forEach(ruby => {
+      const rt = ruby.querySelector('rt');
+      if (rt) {
+        if (rt.offsetWidth > ruby.offsetWidth) {
+          const scale = ruby.offsetWidth / rt.offsetWidth;
+          rt.style.transform = `scaleX(${scale * 0.95})`;
+          rt.style.transformOrigin = 'left';
+        } else {
+          rt.style.transform = 'none';
+        }
+      }
+    });
+    adjustHeaderFontSizeOnOverflow();
+    adjustResultsSummaryFontSize();
+
+    // Create promises for the asynchronous actions
+    const scrollPromise = new Promise(resolve => {
+        setTimeout(() => {
+            if (isPlaying && !isPaused) {
+                const nowPlayingRow = document.getElementById('nowPlaying');
+                if (nowPlayingRow) {
+                    nowPlayingRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+            } else if (lastCenteredRow && document.body.contains(lastCenteredRow)) {
+                lastCenteredRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+            // Approximate scroll completion
+            setTimeout(resolve, 250);
+        }, 0);
+    });
+
+    const popupPromise = new Promise(resolve => {
+        if (activeSelectionPopup) {
+            const popupEl = document.getElementById('selectionPopup');
+            if (popupEl && popupEl.style.display === 'block') {
+                let rectToUse = null;
+                if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
+                    rectToUse = lastAnchorElementForPopup.getBoundingClientRect();
+                } else if (lastRectForPopupPositioning) {
+                    rectToUse = lastRectForPopupPositioning;
+                }
+
+                if (rectToUse) {
+                    requestAnimationFrame(() => {
+                        setTimeout(() => {
+                            if (lastAnchorElementForPopup && !document.body.contains(lastAnchorElementForPopup)) {
+                                return resolve();
+                            }
+                            let currentRect = rectToUse;
+                            if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
+                                currentRect = lastAnchorElementForPopup.getBoundingClientRect();
+                            }
+                            updatePopupPosition(popupEl, currentRect);
+                            resolve();
+                        }, 100);
+                    });
+                } else {
+                    resolve();
+                }
+            } else {
+                resolve();
+            }
+        } else {
+            resolve();
+        }
+    });
+
+    await Promise.all([scrollPromise, popupPromise]);
+
+    // Reset the flag only after all async operations are considered complete
+    isRepositioning = false;
+  }, 150);
+
+  function triggerLayoutUpdate() {
+    // This function is called directly by the event listener.
+    // It sets the flag immediately and then calls the debounced actions.
+    isRepositioning = true;
+    debouncedLayoutUpdateActions();
+  }
+
   let successfullyLoadedFromUrl = false;
 
   const resultsSummaryContainer = document.getElementById('results-summary');
@@ -1769,7 +1897,7 @@ function displayQueryResults(results, keyword, searchMode, summaryText, selected
 
     updateResultsSummaryVisibility();
 
-    setTimeout(() => handleResizeActions(), 0); // Trigger font size adjustment after table is rendered
+    setTimeout(() => triggerLayoutUpdate(), 0); // Trigger font size adjustment after table is rendered
 
     setTimeout(() => {
       const firstResultElement = contentContainer.querySelector('h4, table');
@@ -2007,56 +2135,6 @@ function isFirefox() {
     });
   }
 
-  function handleResizeActions() {
-    const contentContainer = document.getElementById('generated');
-    if (contentContainer) {
-        adjustAllRubyFontSizes(contentContainer);
-    }
-
-    const rubies = document.querySelectorAll('ruby');
-    rubies.forEach(ruby => {
-      const rt = ruby.querySelector('rt');
-      if (rt) {
-        if (rt.offsetWidth > ruby.offsetWidth) {
-          const scale = ruby.offsetWidth / rt.offsetWidth;
-          rt.style.transform = `scaleX(${scale * 0.95})`;
-          rt.style.transformOrigin = 'left';
-        } else {
-          rt.style.transform = 'none';
-        }
-      }
-    });
-
-    adjustHeaderFontSizeOnOverflow();
-    adjustResultsSummaryFontSize();
-
-    if (activeSelectionPopup) {
-      const popupEl = document.getElementById('selectionPopup');
-      if (popupEl && popupEl.style.display === 'block') {
-        let rectToUse = null;
-        if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
-          rectToUse = lastAnchorElementForPopup.getBoundingClientRect();
-        } else if (lastRectForPopupPositioning) {
-          rectToUse = lastRectForPopupPositioning;
-        }
-
-        if (rectToUse) {
-          requestAnimationFrame(() => {
-            setTimeout(() => {
-              if (lastAnchorElementForPopup && !document.body.contains(lastAnchorElementForPopup)) {
-                return;
-              }
-              let currentRect = rectToUse;
-              if (lastAnchorElementForPopup && document.body.contains(lastAnchorElementForPopup)) {
-                   currentRect = lastAnchorElementForPopup.getBoundingClientRect();
-              }
-              updatePopupPosition(popupEl, currentRect);
-            }, 100);
-          });
-        }
-      }
-    }
-  }
 
   
 
@@ -2195,7 +2273,6 @@ function isFirefox() {
     }
   });
 
-  window.addEventListener('resize', debounce(handleResizeActions, 250));
 
   
 // --- 新增：更新網頁標題函式 ---
@@ -2823,7 +2900,7 @@ function renderCategoryItems(itemsToRender, dialectInfo, category, isInitialLoad
         tbody.appendChild(fragment);
     }
     
-    setTimeout(() => handleResizeActions(), 50);
+    setTimeout(() => triggerLayoutUpdate(), 50);
 }
 
 function scrollHandler() {
@@ -3140,7 +3217,10 @@ function setupPlaybackControls(dialectInfo, category, totalRows, autoPlayTargetR
                 currentAudio?.play().catch((e) => console.error('恢復播放失敗:', e));
                 isPaused = false;
                 this.innerHTML = '<i class="fas fa-pause"></i>';
-                if (nowPlayingRow) nowPlayingRow.classList.remove('paused-playback');
+                if (nowPlayingRow) {
+                    nowPlayingRow.classList.remove('paused-playback');
+                    triggerLayoutUpdate();
+                }
             } else {
                 currentAudio?.pause();
                 isPaused = true;
@@ -3553,8 +3633,17 @@ function handleAutoPlay(autoPlayTargetRowId, dialectInfo, category) {
     }
   });
 
-  window.addEventListener('resize', handleResizeActions);
-  handleResizeActions();
+  window.addEventListener('scroll', debouncedUpdateLastCenteredRow);
+  // Set up a ResizeObserver to handle font size changes and other layout shifts
+  if (window.ResizeObserver) {
+    const resizeObserver = new ResizeObserver(triggerLayoutUpdate);
+    resizeObserver.observe(mainContent, { box: 'border-box' });
+  }
+  // Always listen to the resize event as a fallback and for window resizes
+  window.addEventListener('resize', triggerLayoutUpdate);
+
+  // Initial call to set things right
+  triggerLayoutUpdate();
 }
 
 // Start the application


### PR DESCRIPTION
This commit comprehensively overhauls the viewport repositioning logic to ensure a stable scroll position when the window is resized or when playback is paused and resumed.

The previous implementation lost the user's scroll position on resize. This change implements the desired behavior:
- During active playback, the viewport reliably scrolls to the `nowPlaying` row.
- When scrolling manually or when playback is paused, the viewport now tracks the element in the center of the screen (`lastCenteredRow`) and scrolls to keep it centered after a resize.

Key improvements include:
- A new `isRepositioning` flag, managed with `Promise.all`, prevents race conditions by ensuring scroll and popup adjustments complete before new scroll events are tracked.
- The `ResizeObserver` now monitors the `#main-content` container for more efficient and targeted layout change detection.
- Resuming paused playback now correctly triggers a layout update, smoothly scrolling the user back to the active row.
- The old `handleResizeActions` function has been completely replaced with a more robust and clearly named set of functions (`triggerLayoutUpdate`, `debouncedLayoutUpdateActions`).
- Updated `AGENTS.md` to include a guideline on communicating new branch creations.