### PR TITLE
fix: Exclude punctuation from sandhi ruby tags（整 #85）

### DIFF
--- a/main.js
+++ b/main.js
@@ -351,7 +351,7 @@ function getDapuSandhiHtml(htmlContent) {
     const SKIPPABLE_PUNCTUATION = '\\s、';
     const ALL_PUNCTUATION_CHARS = SKIPPABLE_PUNCTUATION + BLOCKING_PUNCTUATION;
 
-    const TOKENIZER_REGEX = new RegExp(`[^<>` + ALL_PUNCTUATION_CHARS + `]+|[${ALL_PUNCTUATION_CHARS}]+`, 'g');
+    const TOKENIZER_REGEX = new RegExp(`[^<>` + ALL_PUNCTUATION_CHARS + `]+|[${SKIPPABLE_PUNCTUATION}]+|[${BLOCKING_PUNCTUATION}]+`, 'g');
     const SKIPPABLE_REGEX = new RegExp(`^[${SKIPPABLE_PUNCTUATION}]+$`);
     const BLOCKING_REGEX = new RegExp(`^[${BLOCKING_PUNCTUATION}]+$`);
 


### PR DESCRIPTION
Corrects the tokenization logic in the `getDapuSandhiHtml` function to prevent punctuation marks, such as parentheses and brackets, from being incorrectly included within the `<ruby>` tags used for marking tone sandhi.

The regular expression for tokenization has been updated to treat these punctuation characters as separate delimiters, ensuring they remain outside the sandhi-marked syllables as intended.

對 #86 徙過來