### PR TITLE
feat: Add debugging logs for popup functionality

### DIFF
--- a/main.js
+++ b/main.js
@@ -225,6 +225,7 @@ function isSourceMatchingDialect(source, dialect) {
 }
 
 function findPronunciationsInAllDataAsync(searchText, callback) {
+  console.log('findPronunciationsInAllDataAsync called with:', searchText);
   if (!searchText || searchText.trim().length === 0) {
     callback([]);
     return;
@@ -268,6 +269,7 @@ function findPronunciationsInAllDataAsync(searchText, callback) {
     if (i < terms.length) {
       setTimeout(processChunk, 0); // Schedule next chunk
     } else {
+      console.log('findPronunciationsInAllDataAsync returned:', foundReadings);
       callback(foundReadings); // All done
     }
   }
@@ -569,6 +571,7 @@ function showPronunciationPopup(selectedText, readings, anchorElementOrRect, cal
 
   // Defer the actual data processing
   findPronunciationsInAllDataAsync(selectedText, (allReadings) => {
+    console.log('renderPronunciationList called with allReadings:', allReadings);
     function renderPronunciationList() {
       contentEl.innerHTML = '';
       const showAllAccents = showOtherAccentsToggle.checked;


### PR DESCRIPTION
This commit adds console.log statements to `main.js` to help debug an issue where the pronunciation popup fails to appear for long text selections.

The changes follow the suggestions provided by Gemini Code Assist in pull request #98. The new logs will trace the execution flow and variable states within the `findPronunciationsInAllDataAsync` and `showPronunciationPopup` functions, providing data to diagnose the root cause of the problem.