### PR TITLE
Replace debounce with throttle for cloud sync to ensure regular uploads

### DIFF
--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -367,25 +367,60 @@ function updateSyncStatusUI(status) {
 }
 
 /**
- * 觸發書籤變更後的雲端同步（防抖）
- * 使用較長的 debounce 時間以減少 API 呼叫次數
+ * 觸發書籤變更後的雲端同步（節流）
+ * 使用 throttle 機制確保播放期間至少每 30 秒上傳一次
+ * 同時在停止操作後也會上傳最終狀態
  */
-let syncDebounceTimer = null;
+let syncThrottleTimer = null;
+let syncTrailingTimer = null;
 let hasPendingSync = false;
+let lastSyncTime = 0;
+const SYNC_INTERVAL = 30000; // 30 秒
 
 function triggerCloudSync() {
   if (!cloudSyncState.isLoggedIn) return;
 
   hasPendingSync = true;
+  const now = Date.now();
 
-  if (syncDebounceTimer) {
-    clearTimeout(syncDebounceTimer);
+  // 清除尾隨計時器（因為有新的變更進來）
+  if (syncTrailingTimer) {
+    clearTimeout(syncTrailingTimer);
+    syncTrailingTimer = null;
   }
 
-  syncDebounceTimer = setTimeout(() => {
+  // 如果距離上次同步已超過 30 秒，立即同步
+  if (now - lastSyncTime >= SYNC_INTERVAL) {
+    // 清除節流計時器（如果有的話）
+    if (syncThrottleTimer) {
+      clearTimeout(syncThrottleTimer);
+      syncThrottleTimer = null;
+    }
+
+    lastSyncTime = now;
     syncToCloud();
     hasPendingSync = false;
-  }, 30000); // 30 秒後同步，減少 Supabase API 呼叫次數
+  } else if (!syncThrottleTimer) {
+    // 還沒到 30 秒，且沒有計時器在跑，設置計時器
+    const remainingTime = SYNC_INTERVAL - (now - lastSyncTime);
+    syncThrottleTimer = setTimeout(() => {
+      syncThrottleTimer = null;
+      lastSyncTime = Date.now();
+      syncToCloud();
+      hasPendingSync = false;
+    }, remainingTime);
+  }
+
+  // 設置尾隨計時器：確保最後一次變更後也會上傳
+  // 這樣停止播放後的最終狀態也能被保存
+  syncTrailingTimer = setTimeout(() => {
+    syncTrailingTimer = null;
+    if (hasPendingSync) {
+      lastSyncTime = Date.now();
+      syncToCloud();
+      hasPendingSync = false;
+    }
+  }, SYNC_INTERVAL);
 }
 
 /**
@@ -395,10 +430,15 @@ function triggerCloudSync() {
 function setupPageUnloadSync() {
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden' && hasPendingSync) {
-      if (syncDebounceTimer) {
-        clearTimeout(syncDebounceTimer);
-        syncDebounceTimer = null;
+      if (syncThrottleTimer) {
+        clearTimeout(syncThrottleTimer);
+        syncThrottleTimer = null;
       }
+      if (syncTrailingTimer) {
+        clearTimeout(syncTrailingTimer);
+        syncTrailingTimer = null;
+      }
+      lastSyncTime = Date.now();
       syncToCloud();
       hasPendingSync = false;
     }


### PR DESCRIPTION
## Summary
Changed the cloud synchronization mechanism from debounce to throttle to ensure more reliable and consistent uploads during playback, while still reducing API call frequency.

## Key Changes
- **Replaced debounce with throttle**: Changed from a single timer that resets on every change to a throttle mechanism that guarantees syncs at least every 30 seconds
- **Added dual-timer system**: 
  - Main throttle timer ensures periodic uploads during active playback
  - Trailing timer captures final state after user stops making changes
- **Improved state tracking**: Added `lastSyncTime` to track when the last sync occurred and calculate remaining time until next sync
- **Enhanced page visibility handling**: Updated cleanup logic to clear both throttle and trailing timers when page becomes hidden

## Implementation Details
- Sync interval set to 30 seconds (`SYNC_INTERVAL = 30000`)
- If 30+ seconds have passed since last sync, upload immediately
- Otherwise, schedule upload for the remaining time until 30 seconds elapse
- Trailing timer (also 30 seconds) ensures final state is captured after user stops interacting
- When page becomes hidden, immediately sync any pending changes and clear all timers

## Benefits
- More predictable sync behavior during playback
- Guarantees uploads at regular intervals rather than only on activity
- Captures final playback state when user stops playing
- Maintains reduced API call frequency compared to per-change syncing