### PR TITLE
fix: [Game] 修正腔調/級別選單與音檔不一致的問題

### DIFF
--- a/js/game/game-data.js
+++ b/js/game/game-data.js
@@ -48,15 +48,20 @@ function normalizeGameData(item, dialect, level, source) {
  */
 function getWordsForDialectAndLevel(dialect, dataVarName) {
   const fullLevelName = getFullLevelName(dataVarName);
-  
-  if (typeof g_currentLevelData === 'undefined' || !g_currentLevelData || g_currentLevelData.length === 0) {
-    console.warn(`No current level data found`);
+
+  // Use window[dataVarName] directly to avoid reading from g_currentLevelData,
+  // which is shared with the main UI and can be mutated independently, causing
+  // a mismatch where question text comes from one level but audio from another.
+  const varData = window[dataVarName];
+  const levelData = (varData && Array.isArray(varData.content)) ? varData.content : [];
+
+  if (levelData.length === 0) {
+    console.warn(`No data found for level: ${dataVarName}`);
     return [];
   }
 
-  return g_currentLevelData.map(item => {
-    // We attach dataVarName in case it's not present natively on the item
-    const newItem = { ...item, dataVarName: item.dataVarName || dataVarName };
+  return levelData.map(item => {
+    const newItem = { ...item, dataVarName: dataVarName };
     return normalizeGameData(newItem, dialect, fullLevelName, 'cert');
   });
 }

--- a/js/game/game-ui.js
+++ b/js/game/game-ui.js
@@ -65,8 +65,6 @@ function initGameUI() {
         const 腔 = varData.name.substring(0, 1);
         const 級 = varData.name.substring(1);
         gameActiveDialect = getDialectInfo(腔, 級).腔名 || '四縣'; // fallback
-        
-        g_currentLevelData = [...varData.content];
 
         document.getElementById('game-target-level').textContent = getFullLevelName(varData.name);
         if (readyBlock) readyBlock.style.display = 'block';
@@ -111,7 +109,6 @@ function initGameUI() {
         if (varData) {
           gameActiveDataVarName = varData.name;
           gameActiveDialect = getDialectInfo(dialect, level).腔名 || '四縣';
-          g_currentLevelData = [...varData.content];
 
           document.getElementById('game-target-level').textContent = getFullLevelName(varData.name);
           document.getElementById('game-setup-select-block').style.display = 'none';


### PR DESCRIPTION
g_currentLevelData 係 main.js 共用个全域變數，
遊戲 modal 修改佢會干擾主頁面个狀態，
主頁面若再加載不同級別，g_currentLevelData 就會變，
但 gameActiveDataVarName 可能仍舊是舊个選擇，
導致出題文字係 A 級，播放音檔卻係 B 級。

修正方式：
- getWordsForDialectAndLevel 改用 window[dataVarName] 直接查資料，
  唔再依賴會被外部修改个 g_currentLevelData
- 移除 game-ui.js 內兩處對 g_currentLevelData 个賦值，
  避免遊戲選關動作污染 main.js 个共用狀態

Co-Authored-By: Claude <noreply@anthropic.com>