### PR TITLE
遊戲出題卡頓時強制先畫出「出題中」遮罩，避免誤觸第一題

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   <script type="text/javascript" src="js/game/phonology-rules.js?v=4.3.2" defer></script>
   <script type="text/javascript" src="js/game/question-gen.js?v=4.6.2" defer></script>
   <script type="text/javascript" src="js/game/srs.js?v=4.3.2" defer></script>
-  <script type="text/javascript" src="js/game/game-ui.js?v=4.6.8" defer></script>
+  <script type="text/javascript" src="js/game/game-ui.js?v=4.6.9" defer></script>
   <script type="text/javascript" src="js/cloud-sync.js?v=4.3.4" defer></script>
   
   <!-- Driver.js for Onboarding -->

--- a/js/game/game-ui.js
+++ b/js/game/game-ui.js
@@ -302,15 +302,26 @@ function getSelectedTypes() {
 async function startSession() {
   const loadingIndicator = document.getElementById('loading-indicator');
   const loadingText = document.getElementById('loading-text');
-  
-  loadingText.textContent = '準備題目中...';
+  const startBtn = document.getElementById('gameStartSessionBtn');
+  const retryBtn = document.getElementById('gameRetryBtn');
+
+  loadingText.textContent = '出題中，請小等一下……';
   loadingIndicator.style.display = 'flex';
+  if (startBtn) startBtn.disabled = true;
+  if (retryBtn) retryBtn.disabled = true;
+
+  // 出題運算在慢速裝置（尤其手機）上是同步且吃重的，會卡住主執行緒數秒。
+  // 若不先讓瀏覽器畫出上面這層遮罩就直接算題，使用者在等待期間亂點的觸控事件
+  // 會被排進佇列，等運算結束、第一題畫面一出現就立刻誤觸到選項——導致第一題答錯。
+  // 用雙重 requestAnimationFrame 確保遮罩「真的畫出來」了，才開始算題，
+  // 讓期間的誤觸都被這層遮罩擋掉，而不是穿透到後面的答案按鈕。
+  await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
   try {
     const orderMode = document.querySelector('input[name="gameOrderMode"]:checked')?.value || 'random';
     const mixMode = document.querySelector('input[name="gameMixMode"]:checked')?.value || 'reviewFirst';
     const types = getSelectedTypes();
-    
+
     currentSession = await generateGameSession(gameActiveDialect, gameActiveDataVarName, { orderMode, mixMode, types });
     currentQuestionIndex = 0;
     score = 0;
@@ -320,7 +331,7 @@ async function startSession() {
     if (typeof trackEvent === 'function') {
       trackEvent('start_session', 'Game', `${gameActiveDataVarName}_${orderMode}_${mixMode}`);
     }
-    
+
     loadingIndicator.style.display = 'none';
     showGameView('play');
     renderQuestion();
@@ -328,6 +339,9 @@ async function startSession() {
     loadingIndicator.style.display = 'none';
     alert('產生題目失敗：' + err.message);
     console.error(err);
+  } finally {
+    if (startBtn) startBtn.disabled = false;
+    if (retryBtn) retryBtn.disabled = false;
   }
 }
 


### PR DESCRIPTION
按「開始挑戰」後，出題運算在慢速裝置上是同步且吃重的，會卡住主執行緒數秒。
過去雖然已經有 loading-indicator 遮罩，但設定 display:flex 後立刻同步呼叫
運算函式，瀏覽器來不及畫出遮罩就先被卡住；使用者在等待期間亂點的觸控事件
會被排進佇列，等運算結束、第一題畫面一出現就立刻誤觸到選項，導致答錯。

用雙重 requestAnimationFrame 確保遮罩真的畫出來後才開始算題，讓期間的誤觸
都被遮罩擋掉；同時停用開始/重玩按鈕防止連點，並把提示文字改成「出題中，
請小等一下」。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F3WvXk9X1oZEZvxGDdhvns