### PR TITLE
fix: 遊戲結束時自動捲動 modal 到最上方，讓窄版螢幕正常顯示鼓勵畫面

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   <script type="text/javascript" src="js/game/phonology-rules.js?v=4.3.2" defer></script>
   <script type="text/javascript" src="js/game/question-gen.js?v=4.8.5" defer></script>
   <script type="text/javascript" src="js/game/srs.js?v=4.8.1" defer></script>
-  <script type="text/javascript" src="js/game/game-ui.js?v=4.10.0" defer></script>
+  <script type="text/javascript" src="js/game/game-ui.js?v=4.10.1" defer></script>
   <script type="text/javascript" src="js/cloud-sync.js?v=4.3.4" defer></script>
   
   <!-- Driver.js for Onboarding -->

--- a/js/game/game-ui.js
+++ b/js/game/game-ui.js
@@ -1149,6 +1149,13 @@ function playAwesomeAudio(targetVarName) {
 
 function endSession() {
   showGameView('result');
+
+  // 自動捲動到結果畫面最上方 (為了窄版螢幕體驗，讓阿翠妹的鼓勵能正常顯示)
+  const resultView = document.getElementById('game-result-view');
+  if (resultView) {
+    resultView.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
   document.getElementById('game-final-score').textContent = score;
   const totalElem = document.getElementById('game-total-questions');
   if (totalElem) totalElem.textContent = currentSession.length;

--- a/js/game/game-ui.js
+++ b/js/game/game-ui.js
@@ -1149,13 +1149,6 @@ function playAwesomeAudio(targetVarName) {
 
 function endSession() {
   showGameView('result');
-
-  // 自動捲動到結果畫面最上方 (為了窄版螢幕體驗，讓阿翠妹的鼓勵能正常顯示)
-  const resultView = document.getElementById('game-result-view');
-  if (resultView) {
-    resultView.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }
-
   document.getElementById('game-final-score').textContent = score;
   const totalElem = document.getElementById('game-total-questions');
   if (totalElem) totalElem.textContent = currentSession.length;
@@ -1180,6 +1173,12 @@ function endSession() {
 
   if (typeof trackEvent === 'function') {
     trackEvent('complete_session', 'Game', `${gameActiveDataVarName}_${score}/${currentSession.length}`);
+  }
+
+  // 自動捲動到結果畫面最上方 (為了窄版螢幕體驗，讓阿翠妹的鼓勵能正常顯示)
+  const resultView = document.getElementById('game-result-view');
+  if (resultView) {
+    resultView.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 }
 


### PR DESCRIPTION
窄螢幕(<=560px)下結果畫面改為直排堆疊，若使用者先前把 modal-body 往下捲
動過，結束遊戲時畫面不會自動回到最上方，導致阿翠妹的鼓勵圖文被裁切在
可視範圍外。比照答題畫面既有的 scrollIntoView 捲動邏輯，在 endSession()
顯示結果畫面時一併捲回最上方。