### PR TITLE
fix(game): exclude variant brackets in cloze option length calculations

### DIFF
--- a/js/game/question-gen.js
+++ b/js/game/question-gen.js
@@ -2,8 +2,28 @@
 // Handles question generation, distractor selection, and session setup
 
 // 載入版本 banner：在 Console 看到這行＝新版 JS 有載到（cache 驗證用）
-const QUESTION_GEN_VERSION = '4.6.2';
+const QUESTION_GEN_VERSION = '4.6.3';
 console.info(`[HakSpring Game] question-gen.js v${QUESTION_GEN_VERSION} loaded`);
+
+/**
+ * Clean Cloze Word by removing bracketed variants and parenthesized content
+ */
+function cleanClozeWord(wordStr) {
+  if (!wordStr) return '';
+  return wordStr
+    .replace(/【.*?】/g, '')
+    .replace(/（.*?）/g, '')
+    .replace(/\(.*?\)/g, '')
+    .trim();
+}
+
+/**
+ * Calculate the Chinese character count (字數) of a word, excluding bracketed/parenthesized content
+ */
+function getChineseCharCount(wordStr) {
+  const clean = cleanClozeWord(wordStr);
+  return (clean.match(/[\u4e00-\u9fff\u3400-\u4dbf]/g) || []).length;
+}
 
 /**
  * Selects exactly n random, unique items from an array.
@@ -373,7 +393,7 @@ async function generateGameSession(dialect, dataVarName, { orderMode = 'random',
     let clozeSentence = null;
     let clozeTarget = null;
     if (chosenType === 'c') {
-      clozeTarget = (target.客家語 || '').replace(/（.*?）/g, '');
+      clozeTarget = cleanClozeWord(target.客家語);
       const sentences = target.例句.split('<br>').map(s => s.trim()).filter(Boolean);
       const validSentences = sentences.filter(s => s.includes(clozeTarget));
       const chosenSent = validSentences[Math.floor(Math.random() * validSentences.length)];
@@ -409,7 +429,7 @@ async function generateGameSession(dialect, dataVarName, { orderMode = 'random',
       let clozeSentence = null;
       let clozeTarget = null;
       if (followType === 'c') {
-        clozeTarget = (q.targetWord.客家語 || '').replace(/（.*?）/g, '');
+        clozeTarget = cleanClozeWord(q.targetWord.客家語);
         const sentences = q.targetWord.例句.split('<br>').map(s => s.trim()).filter(Boolean);
         const validSentences = sentences.filter(s => s.includes(clozeTarget));
         const chosenSent = validSentences[Math.floor(Math.random() * validSentences.length)];
@@ -438,7 +458,7 @@ async function generateGameSession(dialect, dataVarName, { orderMode = 'random',
  */
 function isEligibleForType(targetWord, type) {
   if (type === 'c') {
-    const cleanWord = (targetWord.客家語 || '').replace(/（.*?）/g, '');
+    const cleanWord = cleanClozeWord(targetWord.客家語);
     if (!cleanWord || cleanWord.includes('…')) return false;
     if (!targetWord.例句) return false;
     const sentences = targetWord.例句.split('<br>').map(s => s.trim()).filter(Boolean);
@@ -496,11 +516,13 @@ function buildOptionsForType(target, type, allWords) {
   } else if (type === 'd') {
     options = [target.客家語, ...generateDistractors(target, allWords, '客家語')];
   } else if (type === 'c') {
-    const cleanTarget = (target.客家語 || '').replace(/（.*?）/g, '');
+    const cleanTarget = cleanClozeWord(target.客家語);
+    const targetLength = getChineseCharCount(target.客家語);
     const validPool = allWords.filter(w => {
       if (w.progressKey === target.progressKey) return false;
-      const cleanW = (w.客家語 || '').replace(/（.*?）/g, '');
-      return cleanW && cleanW !== cleanTarget;
+      const cleanW = cleanClozeWord(w.客家語);
+      if (!cleanW || cleanW === cleanTarget) return false;
+      return getChineseCharCount(w.客家語) === targetLength;
     });
     let candidates = validPool.filter(w => target.分類 && w.分類 === target.分類);
     if (candidates.length < 3) {
@@ -513,8 +535,8 @@ function buildOptionsForType(target, type, allWords) {
     while (distractors.length < 3 && candidates.length > 0) {
       const idx = Math.floor(Math.random() * candidates.length);
       const chosen = candidates.splice(idx, 1)[0];
-      const cleanChosen = (chosen.客家語 || '').replace(/（.*?）/g, '');
-      if (!distractors.includes(cleanChosen)) {
+      const cleanChosen = cleanClozeWord(chosen.客家語);
+      if (cleanChosen && !distractors.includes(cleanChosen)) {
         distractors.push(cleanChosen);
       }
     }

--- a/js/game/question-gen.js
+++ b/js/game/question-gen.js
@@ -18,11 +18,18 @@ function cleanClozeWord(wordStr) {
 }
 
 /**
+ * Count Chinese characters (including supplementary plane characters like 𠊎)
+ */
+function countHanChars(cleanStr) {
+  if (!cleanStr) return 0;
+  return (cleanStr.match(/\p{Script=Han}/gu) || []).length;
+}
+
+/**
  * Calculate the Chinese character count (字數) of a word, excluding bracketed/parenthesized content
  */
 function getChineseCharCount(wordStr) {
-  const clean = cleanClozeWord(wordStr);
-  return (clean.match(/[\u4e00-\u9fff\u3400-\u4dbf]/g) || []).length;
+  return countHanChars(cleanClozeWord(wordStr));
 }
 
 /**
@@ -522,7 +529,7 @@ function buildOptionsForType(target, type, allWords) {
       if (w.progressKey === target.progressKey) return false;
       const cleanW = cleanClozeWord(w.客家語);
       if (!cleanW || cleanW === cleanTarget) return false;
-      return getChineseCharCount(w.客家語) === targetLength;
+      return countHanChars(cleanW) === targetLength;
     });
     let candidates = validPool.filter(w => target.分類 && w.分類 === target.分類);
     if (candidates.length < 3) {
@@ -546,18 +553,15 @@ function buildOptionsForType(target, type, allWords) {
     // 20260724 蒂兒：改用「客家語」（漢字）計算音節數，避開拼音欄位中
     // 「又讀」「俗音」「小稱變調讀」等資料陷阱。客語一字一音節。
     const countSyllables = (word) => {
-      const cleaned = (word.客家語 || '')
-        .replace(/【.*?】/g, '')
-        .replace(/（.*?）/g, '');
-      return (cleaned.match(/[\u4e00-\u9fff\u3400-\u4dbf]/g) || []).length;
+      return getChineseCharCount(word.客家語);
     };
     const targetSyllables = countSyllables(target);
     const targetPinyin = target.客語標音_查詢 || '';
+    const cleanTarget = cleanClozeWord(target.客家語);
 
     const validPool = allWords.filter(w => {
       if (w.progressKey === target.progressKey) return false;
-      const cleanW = (w.客家語 || '').replace(/（.*?）/g, '');
-      const cleanTarget = (target.客家語 || '').replace(/（.*?）/g, '');
+      const cleanW = cleanClozeWord(w.客家語);
       if (cleanW === cleanTarget) return false;
       
       const pW = (w.客語標音_查詢 || '').replace(/[\s-]+/g, '');

--- a/js/game/srs.test.js
+++ b/js/game/srs.test.js
@@ -46,3 +46,61 @@ console.assert(state6.reps === 2, 'Reps should be 2');
 console.assert(state6.ef === 230, 'EF should decrease by 0.15 (15)');
 
 console.log('All tests passed successfully!');
+
+console.log('\n--- Question Gen / Cloze Word Length Tests ---');
+const qGenCode = fs.readFileSync('./js/game/question-gen.js', 'utf8');
+
+// Mock browser dependencies for question-gen.js
+const mockWindow = {
+  console: {
+    info: (...args) => console.log(...args),
+    log: (...args) => console.log(...args),
+    warn: (...args) => console.warn(...args)
+  }
+};
+
+// Evaluate question-gen.js in a sandbox
+const qGenContext = {};
+eval(qGenCode);
+
+console.log('Verifying cleanClozeWord:');
+const cleanTestCases = [
+  { input: '發子【病子／發子】', expected: '發子' },
+  { input: '出麻仔【出麻／出麻仔】', expected: '出麻仔' },
+  { input: '恢復（回復）', expected: '恢復' },
+  { input: '腳板（腳盤）【腳盤／腳板（腳盤）】', expected: '腳板' },
+  { input: '嘔【翻／嘔】', expected: '嘔' },
+  { input: '普通', expected: '普通' },
+  { input: '𠊎【𠊎】', expected: '𠊎' },
+  { input: '', expected: '' },
+  { input: null, expected: '' }
+];
+
+for (const tc of cleanTestCases) {
+  const result = cleanClozeWord(tc.input);
+  console.assert(result === tc.expected, `Expected cleanClozeWord("${tc.input}") to be "${tc.expected}", got "${result}"`);
+  console.log(`  cleanClozeWord("${tc.input || ''}") -> "${result}" [OK]`);
+}
+
+console.log('Verifying getChineseCharCount & countHanChars:');
+const lengthTestCases = [
+  { input: '𠊎', expected: 1 },
+  { input: '𠊎自家', expected: 3 },
+  { input: '發子【病子／發子】', expected: 2 },
+  { input: '出麻仔【出麻／出麻仔】', expected: 3 },
+  { input: '恢復（回復）', expected: 2 },
+  { input: '腳板（腳盤）【腳盤／腳板（腳盤）】', expected: 2 },
+  { input: '嘔【翻／嘔】', expected: 1 },
+  { input: '普通', expected: 2 },
+  { input: '𫣆人', expected: 2 },
+  { input: '', expected: 0 },
+  { input: null, expected: 0 }
+];
+
+for (const tc of lengthTestCases) {
+  const result = getChineseCharCount(tc.input);
+  console.assert(result === tc.expected, `Expected getChineseCharCount("${tc.input}") to be ${tc.expected}, got ${result}`);
+  console.log(`  getChineseCharCount("${tc.input || ''}") -> ${result} [OK]`);
+}
+
+console.log('All Cloze and Character Count tests passed successfully!');


### PR DESCRIPTION
Updates the HakSpring game cloze question generation logic to correctly clean up variant brackets 【】 and parentheses （） when calculating character counts and choosing distractors. This ensures variant words are eligible for cloze questions and distractors match target word length correctly.

Fixes #236

---
*PR created automatically by Jules for task [15074697399441533260](https://jules.google.com/task/15074697399441533260) started by @Aiuanyu*