### PR TITLE
Keep game option shortcut numbers fixed to the left of long option text

### DIFF
--- a/js/game/game-ui.js
+++ b/js/game/game-ui.js
@@ -691,9 +691,9 @@ function renderQuestion() {
     }
     
     if (question.type === 'l') {
-      btn.innerHTML = `<kbd class="kbd-shortcut" style="vertical-align: middle; margin-right: 10px;">${index + 1}</kbd> ${displayOpt}`;
+      btn.innerHTML = `<kbd class="kbd-shortcut" style="vertical-align: middle; margin-right: 10px;">${index + 1}</kbd> <span class="game-option-text">${displayOpt}</span>`;
     } else {
-      btn.innerHTML = `<kbd class="kbd-shortcut">${index + 1}</kbd> ${displayOpt}`;
+      btn.innerHTML = `<kbd class="kbd-shortcut">${index + 1}</kbd> <span class="game-option-text">${displayOpt}</span>`;
     }
     btn.dataset.option = comparisonValue;
     btn.onclick = () => handleAnswer(comparisonValue, btn);

--- a/style.css
+++ b/style.css
@@ -4426,7 +4426,26 @@ mark {
   font-size: 1.1em;
   cursor: pointer;
   transition: all 0.2s;
-  text-align: center;
+  text-align: left;
+  display: flex;
+  align-items: center;
+}
+
+.game-option-btn .kbd-shortcut {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8em;
+  height: 1.8em;
+  padding: 0;
+  margin-right: 12px;
+}
+
+.game-option-text {
+  flex-grow: 1;
+  text-align: left;
+  display: block;
 }
 .game-option-btn:hover:not(:disabled) {
   background-color: #e9e9e9;


### PR DESCRIPTION
This change resolves the layout bug where long question/answer options in the game flow under the option shortcut numbers (1, 2, 3, 4).

Changes:
1. In `js/game/game-ui.js`, updated option element generation for all question types to wrap option text inside `<span class="game-option-text">`.
2. In `css/style.css`, updated `.game-option-btn` to use `display: flex; align-items: center; text-align: left;`.
3. In `css/style.css`, kept `.kbd-shortcut` within option buttons to `flex-shrink: 0`, and set fixed sizing with `width: 1.8em; height: 1.8em; margin-right: 12px; display: inline-flex; justify-content: center; align-items: center;`.
4. Verified layout correctness by spawning a live session and injecting a long option string, producing a perfectly aligned and styled multi-line text block next to the shortcut keycap.

Fixes #241

---
*PR created automatically by Jules for task [15469615581930863168](https://jules.google.com/task/15469615581930863168) started by @Aiuanyu*